### PR TITLE
change minimum nodejs version required

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
 
           <h3>npm</h3>
           <p><code>npm install -g purescript</code></p>
-          <p><small>(Installation via <code>npm</code> requires Node version 6 or later)</small></p>
+          <p><small>(Installation via <code>npm</code> requires Node version 8.10.0 or later)</small></p>
 
           <h3>Tools</h3>
           <p>The recommended build tool for beginners is Pulp, which can be installed using <code>npm</code>:</p>


### PR DESCRIPTION
when installing purescript via npm, the minimum version of nodejs has to be 8.10.0